### PR TITLE
chore:

### DIFF
--- a/src/DECK.ino
+++ b/src/DECK.ino
@@ -1,4 +1,4 @@
-#define DECK_VERSION "v1.5.0"
+#define DECK_VERSION "v1.5.1"
 
 // TODO : Refactor debug via services
 #define DECKINO_DEBUG_SERIAL true
@@ -862,6 +862,8 @@ String getRemoteScanLabelFromRemoteData(String remotePlayerId)
   return result;
 }
 
+//
+[[deprecated]]
 String mainMenuActionDtodGetRemoteData(String closestDeckSsid)
 {
   String result = "";

--- a/src/DeckMthrClient.cpp
+++ b/src/DeckMthrClient.cpp
@@ -69,7 +69,33 @@ RessourceResponse DeckMthrClient::DownloadRessource(String relativePath)  {
 
                 // file found at server
                 if (result.httpCode == HTTP_CODE_OK || result.httpCode == HTTP_CODE_MOVED_PERMANENTLY) {
-                    result.payload = http.getString();
+
+                    #if DECKMTHRCLIENT_DEBUG
+                    Serial.print("[DECKMTHRCLIENT][HTTP] Able to download request payload\n");
+                    #endif
+
+                    // get tcp stream
+                    WiFiClient *stream = http.getStreamPtr();
+                    while(stream->available()){
+                        // read char by char to avoid large memory allocation
+                        char c = stream->read();
+                        result.payload += String(c);
+
+                        #if DECKMTHRCLIENT_DEBUG
+                        if(result.payload.length() % 100 == 0){
+                            Serial.print("[DECKMTHRCLIENT][HTTP] Reading request payload ...\n");
+                        }
+                        #endif
+                    }
+
+                    #if DECKMTHRCLIENT_DEBUG
+                    Serial.print("[DECKMTHRCLIENT][HTTP] Succes : End of request payload reached\n");
+                    #endif
+
+                } else {
+                    #if DECKMTHRCLIENT_DEBUG
+                    Serial.print("[DECKMTHRCLIENT][HTTP] Unable to download request payload\n");
+                    #endif
                 }
             } else {
                 #if DECKMTHRCLIENT_DEBUG
@@ -78,12 +104,12 @@ RessourceResponse DeckMthrClient::DownloadRessource(String relativePath)  {
                 #endif
             }
 
-            http.end();
-            } else {
-                #if DECKMTHRCLIENT_DEBUG
-                Serial.printf("[DECKMTHRCLIENT][HTTP] Unable to connect\n");
-                #endif
-            }
+        http.end();
+        } else {
+            #if DECKMTHRCLIENT_DEBUG
+            Serial.printf("[DECKMTHRCLIENT][HTTP] Unable to connect\n");
+            #endif
+        }
 
     }
     return result;


### PR DESCRIPTION
Update DECK_VERSION to v1.5.1
deprecate mainMenuActionDtodGetRemoteData
fix :
Read remote payload request by pointer to avoid memory overflow